### PR TITLE
using rune rather than regex to achieve top speed

### DIFF
--- a/date_test.go
+++ b/date_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fxtlabs/date"
+	"github.com/edgelaboratories/date"
 )
 
 func same(d date.Date, t time.Time) bool {

--- a/example_test.go
+++ b/example_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/fxtlabs/date"
+	"github.com/edgelaboratories/date"
 )
 
 func ExampleMax() {

--- a/format.go
+++ b/format.go
@@ -70,7 +70,7 @@ func parseISORegexp(value string) (Date, error) {
 }
 
 func parseError(input string) error {
-	return fmt.Errorf("Date.ParseISO: length parse %s", input)
+	return fmt.Errorf("Date.ParseISO: cannot parse %s", input)
 }
 
 func parseISORune(value string) (Date, error) {
@@ -89,26 +89,26 @@ func parseISORune(value string) (Date, error) {
 			}
 			continue
 		}
-
 		if state >= 3 {
 			if c != 'T' {
 				return Date{}, parseError(value)
 			}
 			break
 		}
-
 		if unicode.IsDigit(c) {
 			data[state] = data[state]*10 + int(c-'0')
 			characters++
-		} else if c == '-' {
+			continue
+		}
+		if c == '-' {
 			if (state == 0 && characters < 4) || (state != 0 && characters != 2) {
 				return Date{}, parseError(value)
 			}
 			state++
 			characters = 0
-		} else {
-			return Date{}, parseError(value)
+			continue
 		}
+		return Date{}, parseError(value)
 	}
 
 	t := time.Date(yearsign*data[0], time.Month(data[1]), data[2], 0, 0, 0, 0, time.UTC)

--- a/format_bench_test.go
+++ b/format_bench_test.go
@@ -1,0 +1,31 @@
+package date
+
+import "testing"
+
+func BenchmarkFormatISORegexp(b *testing.B) {
+	days := make([]string, 0, b.N)
+	day := Today()
+	for n := 0; n < b.N; n++ {
+		days = append(days, day.String())
+		day.Add(1)
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		parseISORegexp(days[n])
+	}
+}
+
+func BenchmarkFormatISORune(b *testing.B) {
+	days := make([]string, 0, b.N)
+	day := Today()
+	for n := 0; n < b.N; n++ {
+		days = append(days, day.String())
+		day.Add(1)
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		parseISORune(days[n])
+	}
+}

--- a/format_test.go
+++ b/format_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fxtlabs/date"
+	"github.com/edgelaboratories/date"
 )
 
 func TestParseISO(t *testing.T) {


### PR DESCRIPTION
The goal of this PR is to provide a faster ParseISO method, given the eventual ubiquity of this when marshalling and unmarshalling dates.

Observed locally :

```
goos: linux
goarch: amd64
pkg: github.com/edgelaboratories/date
BenchmarkFormatISORegexp-4   	 2000000	       613 ns/op	     128 B/op	       2 allocs/op
BenchmarkFormatISORune-4     	20000000	        93.4 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/edgelaboratories/date	15.316s
```